### PR TITLE
[TH2-1087] Bump 'com.exactpro.th2:common' version to 2.5.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ repositories {
 dependencies {
     constraints {
         // Libraries
-        api('com.exactpro.th2:common:2.4.1')
+        api('com.exactpro.th2:common:2.6.0')
         api('com.exactpro.th2:sailfish-utils:2.2.0')
         api('com.exactpro.th2:check1:2.2.0')
         api('com.exactpro.th2:check2:2.2.0')

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-release_version = 2.10.0
+release_version=2.10.1
 
 bintray_user=
 bintray_key=


### PR DESCRIPTION
Should be merged only after https://github.com/th2-net/th2-common-j/pull/9