### PR TITLE
Revert "Bump org.owasp.dependencycheck from 10.0.4 to 11.1.0"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ kotlin-bom = { group = "org.jetbrains.kotlin", name = "kotlin-bom", version.ref 
 
 [plugins]
 publish-plugin = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
-dependencycheck = { id = "org.owasp.dependencycheck", version = "11.1.0" }
+dependencycheck = { id = "org.owasp.dependencycheck", version = "10.0.4" }
 gradle-git-properties = { id = "com.gorylenko.gradle-git-properties", version = "2.4.2" }
 dependency-license-report = { id = "com.github.jk1.dependency-license-report", version = "2.9" }
 download = { id = "de.undercouch.download", version = "5.6.0" }


### PR DESCRIPTION
Reverts th2-net/th2-bom#44
Failed to process CVE-2022-38176
java.lang.NullPointerException
        at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:271)
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
        at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)
        at java.base/java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1632)
        at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:278)
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
        at java.base/java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1632)
        at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:127)
        at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:502)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:488)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
        at java.base/java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:230)
        at java.base/java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:196)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.anyMatch(ReferencePipeline.java:528)
        at org.owasp.dependencycheck.data.nvdcve.CveItemOperator.testCveCpeStartWithFilter(CveItemOperator.java:229)
        at org.owasp.dependencycheck.data.nvdcve.CveDB.updateVulnerability(CveDB.java:1096)
        at org.owasp.dependencycheck.data.update.nvd.api.NvdApiProcessor.updateCveDb(NvdApiProcessor.java:119)
        at org.owasp.dependencycheck.data.update.nvd.api.NvdApiProcessor.call(NvdApiProcessor.java:96)
        at org.owasp.dependencycheck.data.update.nvd.api.NvdApiProcessor.call(NvdApiProcessor.java:40)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
