### PR TITLE
[GH-129] Update gson:2.13.1 because the 2.8.9 version has CVE-2025-53…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TH2 'Bill of Materials' (BOM) project (4.13.0)
+# TH2 'Bill of Materials' (BOM) project (4.13.1)
 
 This project contains the list of dependencies with their respective versions that are compatible and can be used with each other.
 
@@ -65,6 +65,12 @@ So you can declare that you need any BOM with certain major and minor versions, 
 In most cases it is not necessary, but it might be useful sometimes.
 
 # Release notes:
+
+## 4.13.1
+
+### Updated
+* gson 2.8.9 -> 2.13.1<br>
+  because the 2.8.9 version has CVE-2025-53864 vulnerability
 
 ## 4.13.0
 

--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,10 @@ dependencies {
         api(libs.simpleclient.httpserver)
         api(libs.simpleclient.log4j2)
         api(libs.simpleclient.log4j)
+
+        api(libs.gson) {
+            because("the 2.8.9 version has CVE-2025-53864 vulnerability")
+        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-release_version=4.13.0
+release_version=4.13.1
 description='TH2 "Bill of Materials" (BOM) project'
 vcs_url=https://github.com/th2-net/th2-bom
 nvdApiKey=

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ commons-io = { group = "commons-io", name = "commons-io", version = "2.20.0" }
 commons-cli = { group = "commons-cli", name = "commons-cli", version = "1.9.0" }
 commons-collections4 = { group = "org.apache.commons", name = "commons-collections4", version = "4.5.0" }
 guava = { group = "com.google.guava", name = "guava", version = "33.4.8-jre" }
+gson = { group = "com.google.code.gson", name = "gson", version = "2.13.1" }
 
 grpc-bom = { group = "io.grpc", name = "grpc-bom", version = "1.74.0" }
 protobuf-java-util = { group = "com.google.protobuf", name = "protobuf-java-util", version.ref = "protobuf" }


### PR DESCRIPTION
…864 vulnerability